### PR TITLE
Fix/#47 api response missing exception

### DIFF
--- a/apps/java-api/src/main/java/org/scoalaonline/api/security/SecurityConfig.java
+++ b/apps/java-api/src/main/java/org/scoalaonline/api/security/SecurityConfig.java
@@ -59,9 +59,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     http.authorizeRequests().antMatchers(HttpMethod.GET, "/users/role/**").hasAnyAuthority("ROLE_ADMIN");
     // Custom authorization implemented in UserController.
     http.authorizeRequests().antMatchers(HttpMethod.GET, "/users/username/**").permitAll();
+    http.authorizeRequests().antMatchers(HttpMethod.POST, "/users/register/**").permitAll();
     http.authorizeRequests().antMatchers(HttpMethod.GET, "/users/{id}/**").access("@userSecurity.hasUserId(authentication,#id) or hasAnyAuthority(\"ROLE_ADMIN\")");
     http.authorizeRequests().antMatchers(HttpMethod.POST, "/users/**").hasAnyAuthority("ROLE_ADMIN");
-    http.authorizeRequests().antMatchers(HttpMethod.POST, "/users/register/**").permitAll();
     http.authorizeRequests().antMatchers(HttpMethod.PATCH, "/users/**").hasAnyAuthority("ROLE_ADMIN");
     http.authorizeRequests().antMatchers(HttpMethod.DELETE, "/users/**").hasAnyAuthority("ROLE_ADMIN");
 

--- a/apps/java-api/src/main/resources/application.properties
+++ b/apps/java-api/src/main/resources/application.properties
@@ -1,2 +1,4 @@
 spring.profiles.default=dev
 spring.application.name=${env.APPLICATION_NAME:Scoala-Online}
+
+server.error.include-message=always

--- a/apps/java-api/src/main/resources/application.properties
+++ b/apps/java-api/src/main/resources/application.properties
@@ -2,4 +2,3 @@ spring.profiles.default=dev
 spring.application.name=${env.APPLICATION_NAME:Scoala-Online}
 
 server.error.include-message=always
-server.error.include-exception=true

--- a/apps/java-api/src/main/resources/application.properties
+++ b/apps/java-api/src/main/resources/application.properties
@@ -2,3 +2,4 @@ spring.profiles.default=dev
 spring.application.name=${env.APPLICATION_NAME:Scoala-Online}
 
 server.error.include-message=always
+server.error.include-exception=true


### PR DESCRIPTION
### This pull request solves issue:

Closes: #47

### Which app is this issue related to?

- [x] REST API
- [ ] E-Learning React App
- [ ] ~~Admin Panel~~ - Not created yet

### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Wiki Updates

- [x] No need for updates
- [ ] Requires an update ( _not done within this issue_ )
- [ ] Has been updated ( _done within this issue_ )

### Testing checklist

- [ ] Unit tests
- [ ] Functional tests
- [ ] E2E tests

#### Security Filters - **_For API Only_**

**_Please make sure to add the respective Security Filters before submitting a PR_**

- [ ] They have been added within this issue.

#### Compatibility tests - **_For E-Learning React App Only_**

- [ ] Tested on Safari
- [ ] Tested on Chrome
- [ ] Tested on Mozilla Firefox

### What changes have been done within this issue?

I fixed a bug where the Security filtering would not allow the user to register, by moving the register permission higher up in the filtering sequence.

I fixed the API not providing any message in the error responses.

### How should this be manually tested?

By triggering any exception in any controller. Now the response received from the API should contain a message with the error that occured.

### Screenshots or example usage

![](https://media.discordapp.net/attachments/799723375756312587/894247501228544090/unknown.png)
