### PR TITLE
fix: 🐛 Deny access for unfiltered endpoints

### DIFF
--- a/apps/java-api/src/main/java/org/scoalaonline/api/security/SecurityConfig.java
+++ b/apps/java-api/src/main/java/org/scoalaonline/api/security/SecurityConfig.java
@@ -80,6 +80,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     http.authorizeRequests().antMatchers(HttpMethod.PATCH, "/grades/**").hasAnyAuthority("ROLE_ADMIN");
     http.authorizeRequests().antMatchers(HttpMethod.DELETE, "/grades/**").hasAnyAuthority("ROLE_ADMIN");
 
+    http.authorizeRequests().antMatchers("/**").denyAll();
+
     http.authorizeRequests().anyRequest().authenticated();
 
     http.addFilter(customAuthenticationFilter);


### PR DESCRIPTION
### This pull request solves issue:

Closes: #63 

### Which app is this issue related to?

- [x] REST API
- [ ] E-Learning React App
- [ ] ~~Admin Panel~~ - Not created yet

### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Wiki Updates

- [x] No need for updates
- [ ] Requires an update ( _not done within this issue_ )
- [ ] Has been updated ( _done within this issue_ )

### Testing checklist

- [ ] Unit tests
- [ ] Functional tests
- [ ] E2E tests

#### Security Filters - **_For API Only_**

**_Please make sure to add the respective Security Filters before submitting a PR_**

- [ ] They have been added within this issue.

#### Compatibility tests - **_For E-Learning React App Only_**

- [ ] Tested on Safari
- [ ] Tested on Chrome
- [ ] Tested on Mozilla Firefox

### What changes have been done within this issue?

I added a security filter which denies access to all paths excepting the ones specified above.

### How should this be manually tested?

Try using any unspecified endpoint in the security configuration.

### Screenshots or example usage

<!--- Insert images here -->
