### PR TITLE
Feat/#13 create healtcheck endpoint

### DIFF
--- a/apps/java-api/pom.xml
+++ b/apps/java-api/pom.xml
@@ -18,6 +18,14 @@
 	</properties>
 	<dependencies>
 
+    <!-- Metrics Prometheus -->
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+      <version>1.8.3</version>
+    </dependency>
+
+    <!-- HealthCheck Actuator -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>

--- a/apps/java-api/pom.xml
+++ b/apps/java-api/pom.xml
@@ -17,6 +17,13 @@
 		<java.version>11</java.version>
 	</properties>
 	<dependencies>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+      <version>2.6.3</version>
+    </dependency>
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-neo4j</artifactId>

--- a/apps/java-api/src/main/java/org/scoalaonline/api/healthcheck/RandomHealthIndicator.java
+++ b/apps/java-api/src/main/java/org/scoalaonline/api/healthcheck/RandomHealthIndicator.java
@@ -1,0 +1,25 @@
+package org.scoalaonline.api.healthcheck;
+
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+@Component("random")
+public class RandomHealthIndicator implements HealthIndicator {
+
+  @Override
+  public Health health() {
+    double chance = ThreadLocalRandom.current().nextDouble();
+    // Health builders
+    Health.Builder status = Health.up();
+    if (chance > 0.9) {
+      status = Health.down(new RuntimeException("Bad Luck"));
+    }
+    return status
+      .withDetail("chance", chance)
+      .withDetail("strategy", "thread-local")
+      .build();
+  }
+}

--- a/apps/java-api/src/main/java/org/scoalaonline/api/security/SecurityConfig.java
+++ b/apps/java-api/src/main/java/org/scoalaonline/api/security/SecurityConfig.java
@@ -103,6 +103,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     http.authorizeRequests().antMatchers(HttpMethod.PATCH, "/videos/**").hasAnyAuthority("ROLE_ADMIN");
     http.authorizeRequests().antMatchers(HttpMethod.DELETE, "/videos/**").hasAnyAuthority("ROLE_ADMIN");
 
+    http.authorizeRequests().antMatchers(HttpMethod.GET, "/actuator/**").permitAll();
+    http.authorizeRequests().antMatchers(HttpMethod.POST, "/actuator/**").hasAnyAuthority("ROLE_ADMIN");
+    http.authorizeRequests().antMatchers(HttpMethod.PATCH, "/actuator/**").hasAnyAuthority("ROLE_ADMIN");
+    http.authorizeRequests().antMatchers(HttpMethod.DELETE, "/actuator/**").hasAnyAuthority("ROLE_ADMIN");
+
     http.authorizeRequests().antMatchers("/**").denyAll();
 
     http.authorizeRequests().anyRequest().authenticated();

--- a/apps/java-api/src/main/resources/application.properties
+++ b/apps/java-api/src/main/resources/application.properties
@@ -4,3 +4,4 @@ spring.application.name=${env.APPLICATION_NAME:Scoala-Online}
 server.error.include-message=always
 
 spring.mail.password=${env.MAIL_SENDER_PASSWORD}
+management.endpoints.web.exposure.include=*

--- a/apps/java-api/src/main/resources/application.properties
+++ b/apps/java-api/src/main/resources/application.properties
@@ -4,4 +4,8 @@ spring.application.name=${env.APPLICATION_NAME:Scoala-Online}
 server.error.include-message=always
 
 spring.mail.password=${env.MAIL_SENDER_PASSWORD}
+
+# HealthCheck Endpoint
 management.endpoints.web.exposure.include=*
+management.endpoint.health.show-details=always
+


### PR DESCRIPTION
### This pull request solves issue:

Closes: #13

### Which app is this issue related to?

- [x] REST API
- [ ] E-Learning React App
- [ ] ~~Admin Panel~~ - Not created yet

### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Wiki Updates

- [ ] No need for updates
- [ ] Requires an update ( _not done within this issue_ )
- [ ] Has been updated ( _done within this issue_ )

### Testing checklist

- [ ] Unit tests
- [ ] Functional tests
- [ ] E2E tests

#### Security Filters - **_For API Only_**

**_Please make sure to add the respective Security Filters before submitting a PR_**

- [x] They have been added within this issue.

#### Compatibility tests - **_For E-Learning React App Only_**

- [ ] Tested on Safari
- [ ] Tested on Chrome
- [ ] Tested on Mozilla Firefox

### What changes have been done within this issue?

I've added two dependencies:
- spring-boot-starter-actuator
- micrometer-registry-prometheus
I've added actuator permits in security filters.

### How should this be manually tested?

The application must be running for the endpoint to be checked. For displaying health and metrics about the application, we will be using actuator. At `/actuator` you can see all the available endpoints actuator can provide. The information I used and modified is located at `/actuator/health` and `/actuator/prometheus`
 
#### Health /acutator/health
The health will show by default the status of the site, storage information and database status. Furthermore, custom endpoints can be created (ex: I created the `RandomHealthIndicator` java class in `healthcheck/` package) that will appear at the same path.
This information will display in JSON format using Postman, or accessing the url from browser.

#### Prometheus /acutator/prometheus
The metrics are continuous data that can't be check only by the endpoint, therefore we will use an HTTP API called Prometheus that will ping the endpoint at every 1 minute by default (although this can be modified later in a config file). The API is scraping the endpoint and gathering information that it is later displayed .

*Prometheus setup*
Run the command:
``` $ docker pull prom/prometheus ```
Create the `prometheus.yml` file that contains the following:
```
# my global config
global:
  scrape_interval:     15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
  # scrape_timeout is set to the global default (10s).

# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
rule_files:
  # - "first_rules.yml"
  # - "second_rules.yml"

# A scrape configuration containing exactly one endpoint to scrape:
# Here it's Prometheus itself.
scrape_configs:
  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
  - job_name: 'prometheus'
    # metrics_path defaults to '/metrics'
    # scheme defaults to 'http'.
    static_configs:
    - targets: ['127.0.0.1:9090']

  - job_name: 'spring-actuator'
    metrics_path: '/actuator/prometheus'
    scrape_interval: 5s
    static_configs:
    - targets: ['127.0.0.1:5000']
```
It serves as a config file for the API, where you can set the port it will run, and where is your REST API running.
In this file, I've set the scrape interval to be 15s (line 3).
Then, you will need to start and run Prometheus on a container. 
```bash
$ sudo docker run -d --network=host --name=prometheus -p 9090:9090 -v <ABSOLUTE_PATH_TO_prometheus.yml_FILE>/prometheus.yml:/etc/prometheus/prometheus.yml prom/prometheus --config.file=/etc/prometheus/prometheus.yml
```
Now, by accessing localhost:9090, you can enter the API GUI. At Status > Targets, make sure the status on your application is up. 
![image](https://user-images.githubusercontent.com/45951811/154858247-fdaa97eb-af8c-4e0e-ac99-0bc443933122.png)

Afterwards, in dashboard you can use any of the metrics that appear in /actuator/metrics/
![image](https://user-images.githubusercontent.com/45951811/154858357-89d32ce7-5cb8-49e2-a6c2-8a90ec456ae7.png)

### Screenshots or example usage

<!--- Insert images here -->
